### PR TITLE
add signout button and stop infinite looping for now

### DIFF
--- a/frontend/src/components/compound/Modal/UserListingModal.tsx
+++ b/frontend/src/components/compound/Modal/UserListingModal.tsx
@@ -12,6 +12,7 @@ interface UserListingModalProps {
 }
 
 const UserListingModal: React.FC<UserListingModalProps> = ({ onClose, onSubmitSuccess }) => {
+    // TODO: get current form data from user to prefill form if they have one
 
     const [currentUser, setCurrentUser] = useState<User>()
 

--- a/frontend/src/components/compound/NavBar/UserDropdown.tsx
+++ b/frontend/src/components/compound/NavBar/UserDropdown.tsx
@@ -1,10 +1,25 @@
 import { useEffect, useState } from "react";
 import { UserService } from "../../../lib/services/users/service";
 
+import { getAuth } from 'firebase/auth';
+import firebaseApp from "../../../firebase"; // Ensure you import your firebase configuration
 
 export default function UserDropdown() {
     const [isOpen, setIsOpen] = useState(false);
     const [profileImage, setProfileImage] = useState("");
+
+
+
+    const auth = getAuth(firebaseApp);
+
+    const handleSignOut = async () => {
+        try {
+            await auth.signOut(); // Sign out the user
+            // Optionally handle successful sign-out (e.g., show a message or redirect)
+        } catch (error) {
+            console.error("Error during sign-out:", error); // Handle errors
+        }
+    };
 
     const toggleDropdown = () => {
         setIsOpen(!isOpen);
@@ -35,7 +50,7 @@ export default function UserDropdown() {
                 <div className="absolute right-20 mt-2 w-48 bg-white border border-gray-200 rounded shadow-lg">
                     <a href="#" className="block px-4 py-2 text-gray-800 hover:bg-gray-100">Settings</a>
                     <a href="#" className="block px-4 py-2 text-gray-800 hover:bg-gray-100">Edit my listing</a>
-                    <a href="#" className="block px-4 py-2 text-gray-800 hover:bg-gray-100">Sign out</a>
+                    <button onClick={handleSignOut} className="block px-4 py-2 text-gray-800 hover:bg-gray-100">Sign out</button>
                 </div>
             )}
         </div>

--- a/frontend/src/components/layouts/UnprotectedLayout.tsx
+++ b/frontend/src/components/layouts/UnprotectedLayout.tsx
@@ -6,20 +6,21 @@ import { useEffect } from "react";
 const UnprotectedLayout: React.FC = () => {
     const navigate = useNavigate();
 
-    useEffect(() => {
-        (async () => {
-            const userService = UserService(); // Ensure UserService has a constructor
-            try {
-                const user = await userService.getCurrentUser(); // Use the instance to call the method
-                if (user.data?.id) {
-                    navigate('/');
-                }
-            } catch (error) {
-                console.error("Error fetching current user:", error); // Log the error
-            }
+    // useEffect(() => {
+    //     (async () => {
+    //         const userService = UserService(); // Ensure UserService has a constructor
+    //         try {
+    //             const user = await userService.getCurrentUser(); // Use the instance to call the method
+    //             if (user.data?.id) {
+    //                 navigate('/');
+    //             }
+    //         } catch (error) {
+    //             console.error("Error fetching current user:", error); // Log the error
+    //             return
+    //         }
 
-        })();
-    }, []);
+    //     })();
+    // }, []);
 
     return (
         <div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 91d3859c916b7373e768afd51f558613203834bb  | 
|--------|--------|

### Summary:
Added sign-out functionality in `UserDropdown` and commented out `useEffect` in `UnprotectedLayout` to prevent infinite loop.

**Key points**:
- Added `handleSignOut` function in `frontend/src/components/compound/NavBar/UserDropdown.tsx` to sign out users using Firebase authentication.
- Replaced "Sign out" link with a button in `UserDropdown` to trigger `handleSignOut`.
- Commented out `useEffect` in `frontend/src/components/layouts/UnprotectedLayout.tsx` to prevent infinite loop when fetching current user.
- Added a TODO comment in `frontend/src/components/compound/Modal/UserListingModal.tsx` for pre-filling form data.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->